### PR TITLE
Added filename return for rackspace upload_file

### DIFF
--- a/libraries/rackspace_cf_driver.php
+++ b/libraries/rackspace_cf_driver.php
@@ -83,6 +83,8 @@ class Rackspace_Cf_Driver extends Storage
 		}
 		
 		$my_object->load_from_filename($path);
+
+		return ($my_object->container->cdn_enabled) ? $my_object->container->cdn_uri . '/' . $my_object->name : $my_object->name;
 	}
 	
 	//


### PR DESCRIPTION
Checks if CDN is enabled or not, returns the full path to uploaded file so it can be stored in your application.
