### PR TITLE
S3 metadata

### DIFF
--- a/libraries/amazon_s3_driver.php
+++ b/libraries/amazon_s3_driver.php
@@ -81,7 +81,7 @@ class Amazon_S3_Driver extends Storage
 	//
 	// Upload a file to a bucket.
 	//
-	function upload_file($cont, $path, $name, $type = NULL, $acl = 'private')
+	function upload_file($cont, $path, $name, $type = NULL, $acl = 'private', $metadata = array())
 	{
 		$input = array('file' => $path);
 		
@@ -97,7 +97,7 @@ class Amazon_S3_Driver extends Storage
 			$acl = 'public-read';
 		}
 	
-		$this->_CI->s3->putObject($input, $cont, $name, $acl);
+		$this->_CI->s3->putObject($input, $cont, $name, $acl, array(), $metadata);
 	}
 	
 	//

--- a/libraries/rackspace_cf_driver.php
+++ b/libraries/rackspace_cf_driver.php
@@ -67,9 +67,9 @@ class Rackspace_Cf_Driver extends Storage
 	}
 
 	//
-	// Upload file to a container. At this point $acl does not do anything.
+	// Upload file to a container. At this point $acl and $metadata does not do anything.
 	//
-	function upload_file($cont, $path, $name, $type = NULL, $acl = 'private')
+	function upload_file($cont, $path, $name, $type = NULL, $acl = 'private', $metadata = array())
 	{
 		$my_container = $this->_conn->get_container($cont);
 

--- a/libraries/storage.php
+++ b/libraries/storage.php
@@ -82,9 +82,9 @@ class Storage
 	//
 	// Upload file.
 	//
-	function upload_file($cont, $path, $name, $type = NULL, $acl = 'private')
+	function upload_file($cont, $path, $name, $type = NULL, $acl = 'private', $metadata = array())
 	{
-		return $this->_CI->{$this->_driver}->upload_file($cont, $path, $name, $type, $acl);
+		return $this->_CI->{$this->_driver}->upload_file($cont, $path, $name, $type, $acl, $metadata);
 	}
 	
 	//


### PR DESCRIPTION
Amazon allows users to set metadata for uploaded files, for example the Cache-Control header. Updated library to pass this information down to the S3 driver. Ignored for Rackspace uploads.
